### PR TITLE
feat: Update AdditionalContext to include extension ID

### DIFF
--- a/docs/type-aliases/AdditionalContext.md
+++ b/docs/type-aliases/AdditionalContext.md
@@ -6,7 +6,7 @@
 
 # Type Alias: AdditionalContext\<T\>
 
-> **AdditionalContext**\<`T`\>: \{ `additionalContextType`: [`AdditionalContextTypes`](../enumerations/AdditionalContextTypes.md); `additionalContextValues`: [`AdditionalContextValues`](AdditionalContextValues.md)\<`T`\>; \}
+> **AdditionalContext**\<`T`\>: \{ `additionalContextType`: [`AdditionalContextTypes`](../enumerations/AdditionalContextTypes.md); `additionalContextValues`: [`AdditionalContextValues`](AdditionalContextValues.md)\<`T`\>; `extensionId`: `string`; \}
 
 ## Type Parameters
 
@@ -21,3 +21,7 @@
 ### additionalContextValues
 
 > **additionalContextValues**: [`AdditionalContextValues`](AdditionalContextValues.md)\<`T`\>
+
+### extensionId
+
+> **extensionId**: `string`

--- a/src/types/generationContext/GenerationContext.ts
+++ b/src/types/generationContext/GenerationContext.ts
@@ -41,6 +41,7 @@ export enum AdditionalContextTypes {
 export type AdditionalContextValues<T> = T[];
 
 export type AdditionalContext<T> = {
+  extensionId: string;
   additionalContextType: AdditionalContextTypes;
   additionalContextValues: AdditionalContextValues<T>;
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -32,6 +32,8 @@ import {
   SectionGenerationContext,
 } from "../src";
 
+const TEST_EXTENSION_ID = "test-extension-id";
+
 describe("SDK Exports", () => {
   it("should export ExperienceService", () => {
     expect(ExperienceService).toBeDefined();
@@ -144,6 +146,7 @@ describe("SDK Exports", () => {
     expect(additionalContextValues.length).toBe(1);
 
     const additionalContext: AdditionalContext<Claim> = {
+      extensionId: TEST_EXTENSION_ID,
       additionalContextType: AdditionalContextTypes.Claims,
       additionalContextValues,
     };

--- a/tests/types/generationContext/GenerationContext.test.ts
+++ b/tests/types/generationContext/GenerationContext.test.ts
@@ -22,6 +22,8 @@ import {
   GenerationContext,
 } from "../../../src/types/generationContext/GenerationContext";
 
+const TEST_EXTENSION_ID = "test-extension-id";
+
 describe("contract", () => {
   it("should define Brand", () => {
     const brand: Brand = {
@@ -89,6 +91,7 @@ describe("contract", () => {
       },
     ];
     const additionalContext: AdditionalContext<any> = {
+      extensionId: TEST_EXTENSION_ID,
       additionalContextType: AdditionalContextTypes.Claims,
       additionalContextValues: additionalContextValues,
     };
@@ -109,6 +112,7 @@ describe("contract", () => {
       },
     ];
     const additionalContext: AdditionalContext<any> = {
+      extensionId: TEST_EXTENSION_ID,
       additionalContextType: AdditionalContextTypes.Claims,
       additionalContextValues: additionalContextValues,
     };
@@ -140,6 +144,7 @@ describe("contract", () => {
       },
     ];
     const additionalContext: AdditionalContext<any> = {
+      extensionId: TEST_EXTENSION_ID,
       additionalContextType: AdditionalContextTypes.Claims,
       additionalContextValues: additionalContextValues,
     };
@@ -184,6 +189,7 @@ describe("contract", () => {
       },
     ];
     const additionalContext = {
+      extensionId: TEST_EXTENSION_ID,
       additionalContextType: AdditionalContextTypes.Claims,
       additionalContextValues: additionalContextValues,
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

To load the add on in the prompt drawer in Canvas/Draft view, we need to store the extension ID for each additional context that we add.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.