### PR TITLE
fix: support experiences from create that are already formatted correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/adobe/genstudio-uix-sdk.git"
@@ -46,17 +48,21 @@
     "jest": "^29.7.0",
     "semantic-release": "^24.2.1",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.7.3",
     "typedoc": "^0.27.0",
     "typedoc-plugin-markdown": "^4.0.1",
-    "typedoc-plugin-zod": "^1.1.2"
+    "typedoc-plugin-zod": "^1.1.2",
+    "typescript": "^5.7.3"
   },
   "jest": {
     "preset": "ts-jest",
     "testEnvironment": "node",
     "collectCoverage": true,
     "coverageDirectory": "coverage",
-    "coverageReporters": ["text", "lcov", "html"],
+    "coverageReporters": [
+      "text",
+      "lcov",
+      "html"
+    ],
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",
       "!src/**/index.ts",

--- a/src/types/experience/ExperienceService.ts
+++ b/src/types/experience/ExperienceService.ts
@@ -53,7 +53,7 @@ export class ExperienceService {
       // @ts-ignore Remote API is handled through postMessage
       const experiences = await connection.host.api.createRightPanel.getExperiences();
 
-      // check if experiences is arlready of type Experience[]
+      // check if experiences is already of type Experience[]
       if (
         experiences &&
         experiences.length > 0 &&

--- a/tests/types/experience/ExperienceService.test.ts
+++ b/tests/types/experience/ExperienceService.test.ts
@@ -149,5 +149,26 @@ describe('ExperienceService', () => {
         .rejects
         .toThrow('Connection is required to get experiences');
     });
+    it('should handle already converted experiences', async () => {
+      const mockGetExperiences = jest.fn().mockResolvedValue([{
+        id: 'exp123',
+        experienceFields: {
+          name: {
+            fieldName: 'name',
+            fieldValue: 'Test Experience'
+          }
+        }
+      }]);
+      const mockConnection = createMockConnection(mockGetExperiences);
+
+      const results = await ExperienceService.getExperiences(mockConnection);
+      
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('exp123');
+      expect(results[0].experienceFields.name).toEqual({
+        fieldName: 'name',
+        fieldValue: 'Test Experience'
+      });
+    });
   });
 }); 


### PR DESCRIPTION
Add support for Create returning the raw experience and the converted experience

## Description
Works with changes to create: https://git.corp.adobe.com/GenStudio/create/pull/1651
![Screen Shot 2025-01-30 at 1 55 56 PM](https://github.com/user-attachments/assets/4678db23-32ac-492f-88fe-223f1af8ebbb)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.