### PR TITLE
fix: Add hook for closing Add On Dialog

### DIFF
--- a/src/types/extensionRegistration/ExtenstionRegistration.ts
+++ b/src/types/extensionRegistration/ExtenstionRegistration.ts
@@ -66,4 +66,12 @@ export class ExtensionRegistrationService {
     return guestConnection.host.api.dialogs_context.open(`${appExtensionId}`);
     // return guestConnection.host.api.createContextAddOns.openDialog(`${appExtensionId}`);
   }
+
+  /**
+   * close the add context add on dialog
+   * @param guestConnection - the guest connection
+   */
+  static closeAddContextAddOnBar(guestConnection: any) {
+    return guestConnection.host.api.dialogs_context.close();
+  }
 }

--- a/src/types/extensionRegistration/ExtenstionRegistration.ts
+++ b/src/types/extensionRegistration/ExtenstionRegistration.ts
@@ -72,6 +72,8 @@ export class ExtensionRegistrationService {
    * @param guestConnection - the guest connection
    */
   static closeAddContextAddOnBar(guestConnection: any) {
+    // support only old api for now
     return guestConnection.host.api.dialogs_context.close();
+    // return guestConnection.host.api.createContextAddOns.closeDialog();
   }
 }

--- a/tests/types/extensionRegistration/ExperienceRegistration.test.ts
+++ b/tests/types/extensionRegistration/ExperienceRegistration.test.ts
@@ -13,42 +13,60 @@ governing permissions and limitations under the License.
 import { ExtensionRegistrationService, ExtensionRegistrationError } from "../../../src/types/extensionRegistration/ExtenstionRegistration";
 
 describe('ExtensionRegistrationService', () => {
-    const mockAppExtensionId = 'test-extension-id';
+  const mockAppExtensionId = 'test-extension-id';
 
-    describe('openCreateAddOnBar', () => {
-      it('should support opening the add on bar', async () => {
-        const mockGuestConnection = {
-          host: {
-            api: {
-              dialogs: {
-                open: jest.fn().mockResolvedValue(undefined)
-              }
+  describe('openCreateAddOnBar', () => {
+    it('should support opening the add on bar', async () => {
+      const mockGuestConnection = {
+        host: {
+          api: {
+            dialogs: {
+              open: jest.fn().mockResolvedValue(undefined)
             }
           }
-        };
-  
-        await ExtensionRegistrationService.openCreateAddOnBar(mockGuestConnection, mockAppExtensionId);
-        
-        expect(mockGuestConnection.host.api.dialogs.open)
-          .toHaveBeenCalledWith(mockAppExtensionId);
-      });
-    });
+        }
+      };
 
-    describe('openAddContextAddOnBar', () => {
-        it('should support opening the add context add on bar', async () => {
-            const mockGuestConnection = {
-                host: {
-                    api: {
-                        dialogs_context: {  
-                            open: jest.fn().mockResolvedValue(undefined)
-                        }
-                    }
-                }
-            };
-            await ExtensionRegistrationService.openAddContextAddOnBar(mockGuestConnection, mockAppExtensionId); 
-            
-            expect(mockGuestConnection.host.api.dialogs_context.open)
-                .toHaveBeenCalledWith(mockAppExtensionId);
-        });
+      await ExtensionRegistrationService.openCreateAddOnBar(mockGuestConnection, mockAppExtensionId);
+
+      expect(mockGuestConnection.host.api.dialogs.open)
+        .toHaveBeenCalledWith(mockAppExtensionId);
     });
+  });
+
+  describe('openAddContextAddOnBar', () => {
+    it('should support opening the add context add on bar', async () => {
+      const mockGuestConnection = {
+        host: {
+          api: {
+            dialogs_context: {
+              open: jest.fn().mockResolvedValue(undefined)
+            }
+          }
+        }
+      };
+      await ExtensionRegistrationService.openAddContextAddOnBar(mockGuestConnection, mockAppExtensionId);
+
+      expect(mockGuestConnection.host.api.dialogs_context.open)
+        .toHaveBeenCalledWith(mockAppExtensionId);
+    });
+  });
+
+  describe('closeAddContextAddOnBar', () => {
+    it('should support closing the add context add on bar', async () => {
+      const mockGuestConnection = {
+        host: {
+          api: {
+            dialogs_context: {
+              close: jest.fn().mockResolvedValue(undefined)
+            }
+          }
+        }
+      };
+      await ExtensionRegistrationService.closeAddContextAddOnBar(mockGuestConnection);
+
+      expect(mockGuestConnection.host.api.dialogs_context.close)
+        .toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a hook so that the context add on dialog can be closed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.