### PR TITLE
fix: Add user prompt to Generation Context

### DIFF
--- a/docs/api/classes/ExperienceService.md
+++ b/docs/api/classes/ExperienceService.md
@@ -93,3 +93,19 @@ Promise<Experience[]> Array of converted experiences
 #### Throws
 
 Error if connection is missing
+
+***
+
+### getGenerationContext()
+
+> `static` **getGenerationContext**(`connection`: `GuestUI`\<[`RightPanelApi`](../interfaces/RightPanelApi.md)\>): `Promise`\<[`GenerationContext`](../type-aliases/GenerationContext.md)\>
+
+#### Parameters
+
+##### connection
+
+`GuestUI`\<[`RightPanelApi`](../interfaces/RightPanelApi.md)\>
+
+#### Returns
+
+`Promise`\<[`GenerationContext`](../type-aliases/GenerationContext.md)\>

--- a/docs/api/classes/ExtensionRegistrationService.md
+++ b/docs/api/classes/ExtensionRegistrationService.md
@@ -20,6 +20,26 @@ Manages extension registration
 
 ## Methods
 
+### closeAddContextAddOnBar()
+
+> `static` **closeAddContextAddOnBar**(`guestConnection`: `any`): `any`
+
+close the add context add on dialog
+
+#### Parameters
+
+##### guestConnection
+
+`any`
+
+the guest connection
+
+#### Returns
+
+`any`
+
+***
+
 ### openAddContextAddOnBar()
 
 > `static` **openAddContextAddOnBar**(`guestConnection`: `any`, `appExtensionId`: `string`): `any`

--- a/docs/api/interfaces/RightPanelApi.md
+++ b/docs/api/interfaces/RightPanelApi.md
@@ -18,11 +18,11 @@
 
 ### api
 
-> **api**: \{ `createRightPanel`: \{ `getExperiences`: () => `Promise`\<`any`[]\>; \}; \}
+> **api**: \{ `createRightPanel`: \{ `getExperiences`: () => `Promise`\<`any`[]\>; `getGenerationContext`: () => `Promise`\<`any`\>; \}; \}
 
 #### createRightPanel
 
-> **createRightPanel**: \{ `getExperiences`: () => `Promise`\<`any`[]\>; \}
+> **createRightPanel**: \{ `getExperiences`: () => `Promise`\<`any`[]\>; `getGenerationContext`: () => `Promise`\<`any`\>; \}
 
 ##### createRightPanel.getExperiences()
 
@@ -31,3 +31,11 @@
 ###### Returns
 
 `Promise`\<`any`[]\>
+
+##### createRightPanel.getGenerationContext()
+
+> **getGenerationContext**: () => `Promise`\<`any`\>
+
+###### Returns
+
+`Promise`\<`any`\>

--- a/docs/api/type-aliases/GenerationContext.md
+++ b/docs/api/type-aliases/GenerationContext.md
@@ -6,7 +6,7 @@
 
 # Type Alias: GenerationContext
 
-> **GenerationContext**: \{ `additionalContexts`: `Record`\<`string`, [`AdditionalContext`](AdditionalContext.md)\<`any`\>\>; `brand`: [`Brand`](Brand.md); `channel`: [`Channel`](Channel.md); `id`: `string`; `persona`: [`Persona`](Persona.md); `product`: [`Product`](Product.md); `sections`: [`SectionGenerationContext`](SectionGenerationContext.md)[]; \}
+> **GenerationContext**: \{ `additionalContexts`: `Record`\<`string`, [`AdditionalContext`](AdditionalContext.md)\<`any`\>\>; `brand`: [`Brand`](Brand.md); `channel`: [`Channel`](Channel.md); `id`: `string`; `persona`: [`Persona`](Persona.md); `product`: [`Product`](Product.md); `sections`: [`SectionGenerationContext`](SectionGenerationContext.md)[]; `userPrompt`: `string`; \}
 
 ## Type declaration
 
@@ -37,3 +37,7 @@
 ### sections?
 
 > `optional` **sections**: [`SectionGenerationContext`](SectionGenerationContext.md)[]
+
+### userPrompt
+
+> **userPrompt**: `string`

--- a/src/types/experience/ExperienceService.ts
+++ b/src/types/experience/ExperienceService.ts
@@ -14,11 +14,13 @@ import { Experience, ExperienceField } from "./Experience";
 
 import { GuestUI } from "@adobe/uix-guest";
 import { VirtualApi } from "@adobe/uix-core";
+import { GenerationContext } from "../generationContext/GenerationContext";
 
 export interface RightPanelApi extends VirtualApi {
   api: {
     createRightPanel: {
       getExperiences: () => Promise<any[]>;
+      getGenerationContext: () => Promise<any>;
     };
   };
 }
@@ -111,5 +113,19 @@ export class ExperienceService {
     return rawExperiences.map(exp =>
       this.convertRawExperienceToExperience(exp),
     );
+  }
+
+  static async getGenerationContext(
+    connection: GuestUI<RightPanelApi>
+  ): Promise<GenerationContext> {
+    if (!connection) {
+      throw new ExperienceError("Connection is required to get generation context");
+    }
+    try {
+      // @ts-ignore Remote API is handled through postMessage
+      return await connection.host.api.createRightPanel.getGenerationContext();
+    } catch (error) {
+      throw new ExperienceError("Failed to get generation context");
+    }
   }
 }

--- a/src/types/generationContext/GenerationContext.ts
+++ b/src/types/generationContext/GenerationContext.ts
@@ -54,6 +54,7 @@ export type SectionGenerationContext = {
 
 export type GenerationContext = {
   id: string;
+  userPrompt: string;
   channel?: Channel;
   additionalContexts?: Record<string, AdditionalContext<any>>;
   brand?: Brand;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -162,6 +162,7 @@ describe("SDK Exports", () => {
 
     const generationContext: GenerationContext = {
       id: "test",
+      userPrompt: "my user prompt",
       channel: Email,
       brand,
       product,

--- a/tests/types/generationContext/GenerationContext.test.ts
+++ b/tests/types/generationContext/GenerationContext.test.ts
@@ -157,6 +157,7 @@ describe("contract", () => {
     };
     const generationContext: GenerationContext = {
       id: "1234",
+      userPrompt: "my user prompt",
       channel: {
         id: "Email",
         name: "Email",
@@ -207,6 +208,7 @@ describe("contract", () => {
     };
     const generationContext: GenerationContext = {
       id: "1234",
+      userPrompt: "my user prompt",
       channel: {
         id: "Email",
         name: "Email",
@@ -230,12 +232,14 @@ describe("contract", () => {
     expect(generationContext.sections?.[0]).toEqual(sectionGenerationContext);
   });
 
-  it("should define a generationContext with empty values except id", () => {
+  it("should define a generationContext with empty values except id and userPrompt", () => {
     const generationContext: GenerationContext = {
       id: "1234",
+      userPrompt: "my user prompt",
     };
     expect(generationContext).toBeDefined();
     expect(generationContext.id).toBe("1234");
+    expect(generationContext.userPrompt).toBe("my user prompt");
     expect(generationContext.channel).toBeUndefined();
     expect(generationContext.brand).toBeUndefined();
     expect(generationContext.persona).toBeUndefined();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

https://jira.corp.adobe.com/browse/GS-10389

- Added user prompt as a property of Generation Context
- Added a hook in ExperienceService to fetch the Generation Context

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.