### PR TITLE
feat: Send image url in Experience object to guest app

### DIFF
--- a/src/types/generationContext/GenerationContext.ts
+++ b/src/types/generationContext/GenerationContext.ts
@@ -50,6 +50,7 @@ export type SectionGenerationContext = {
   id: string;
   additionalContexts?: AdditionalContext<any>[];
   product?: Product;
+  imageUrl?: string;
 };
 
 export type GenerationContext = {
@@ -60,5 +61,6 @@ export type GenerationContext = {
   brand?: Brand;
   product?: Product;
   persona?: Persona;
+  imageUrl?: string;
   sections?: SectionGenerationContext[] | undefined;
 };

--- a/tests/types/generationContext/GenerationContext.test.ts
+++ b/tests/types/generationContext/GenerationContext.test.ts
@@ -239,4 +239,36 @@ describe("contract", () => {
     expect(generationContext.persona).toBeUndefined();
     expect(generationContext.sections).toBeUndefined();
   });
+
+  it("should define a generationContext with imageUrl", () => {
+    const generationContext: GenerationContext = {
+      id: "1234",
+      userPrompt: "my user prompt",
+      imageUrl: "https://example.com/image.jpg",
+    };
+    expect(generationContext).toBeDefined();
+    expect(generationContext.id).toBe("1234");
+    expect(generationContext.userPrompt).toBe("my user prompt");
+    expect(generationContext.imageUrl).toBe("https://example.com/image.jpg");
+  });
+
+  it("should define a generationContext with imageUrl and sections", () => {
+    const generationContext: GenerationContext = {
+      id: "1234",
+      userPrompt: "my user prompt",
+      sections: [
+        {
+          id: "1",
+          imageUrl: "https://example.com/image.jpg",
+        },
+      ],
+    };
+    expect(generationContext).toBeDefined();
+    expect(generationContext.id).toBe("1234");
+    expect(generationContext.userPrompt).toBe("my user prompt");
+    expect(generationContext.sections).toBeDefined();
+    expect(generationContext.sections?.[0].imageUrl).toBe(
+      "https://example.com/image.jpg",
+    );
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added an imageUrl field to the GenerationContext. This contains the signed URL from delivery for image(s) that are used in the Experience.

## Related Issue

https://jira.corp.adobe.com/browse/GS-12426

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.